### PR TITLE
Makefile: make docker command restartable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,16 @@
-.PHONY: docker-run docker-run-special docker-run-ultra
+.PHONY: docker-run docker-run-special docker-run-ultra docker-down
 
-
-docker-run:
-	docker-compose down -v
+docker-run: docker-down
 	docker-compose up -d --force-recreate --build
 
-docker-run-special:
-	docker-compose -f docker-compose-special.yml down -v
+docker-run-special: docker-down
 	docker-compose -f docker-compose-special.yml up -d --force-recreate --build
 
-docker-run-ultra:
-	docker-compose -f docker-compose-ultra.yml down -v
+docker-run-ultra: docker-down
 	docker-compose -f docker-compose-ultra.yml up -d --force-recreate --build
 
+docker-down:
+	docker-compose -f docker-compose.yml \
+		-f docker-compose-special.yml \
+		-f docker-compose-ultra.yml \
+		down -v


### PR DESCRIPTION
# Issue
Make commands fail when docker containers started by a different docker-compose file.

```
> make docker-run
docker-compose down -v
WARNING: Found orphan containers (gh-ost-sandbox_sp-b-db-replica-2_1, gh-ost-sandbox_sp-b-db-replica-1_1, gh-ost-sandbox_sp-a-db-replica-2_1, gh-ost-sandbox_sp-a-db-replica-1_1, gh-ost-sandbox_sp-db-replica-msr_1, gh-ost-sandbox_sp-b-db-master_1, gh-ost-sandbox_sp-a-db-master_1) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up.
Removing network gh-ost-sandbox_default
ERROR: error while removing network: network gh-ost-sandbox_default id 4108628d90de359e64cccfe30db7502b0492494cd0829313e7dba975e4933056 has active endpoints
make: *** [docker-run] Error 1
```

# Proposal
Run `docker-compose down` against all `docker-compose.*.yml` files