### PR TITLE
mysql:5.7 is no longer based on Debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:5.7
+FROM mysql:5.7-debian
 
 # https://dev.mysql.com/doc/mysql-apt-repo-quick-guide/en/#repo-qg-apt-repo-manual-setup
 RUN apt-key adv --keyserver pgp.mit.edu --recv-keys 3A79BD29


### PR DESCRIPTION
The default image for mysql:5.7 on hub.docker.com is based on Oracle Linux, which is in turn based on Fedora. It does not have `apt` utilities.

So, I replaced the base image to be one that is based on Debian instead.

    $ docker run mysql:5.7 grep PRETTY_NAME /etc/os-release
    PRETTY_NAME="Oracle Linux Server 7.9"

    $ docker run mysql:5.7-debian grep PRETTY_NAME /etc/os-release
    PRETTY_NAME="Debian GNU/Linux 10 (buster)"