### PR TITLE
Replace old public key of MySQL debian package repository with the new key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM mysql:5.7-debian
 
 # https://dev.mysql.com/doc/mysql-apt-repo-quick-guide/en/#repo-qg-apt-repo-manual-setup
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys 3A79BD29
+RUN gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys A8D3785C && \
+    rm /etc/apt/keyrings/mysql.gpg && \
+    gpg --output /etc/apt/keyrings/mysql.gpg --export A8D3785C
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends --no-install-suggests \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,10 @@ services:
       - ./99-touch-OK.sh:/docker-entrypoint-initdb.d/99-touch-OK.sh
     command:
       - --server_id=1
+    ports:
+      - "8889:3306"
+    networks:
+      - db-network
   db-replica-1:
     build:
       context: .
@@ -30,6 +34,10 @@ services:
       - --server_id=2
     depends_on:
       - db-master
+    ports:
+      - "8888:3306"
+    networks:
+      - db-network
   db-replica-2:
     build:
       context: .
@@ -45,3 +53,10 @@ services:
       - --server_id=3
     depends_on:
       - db-master
+    ports:
+      - "8887:3306"
+    networks:
+      - db-network
+
+networks:
+  db-network:


### PR DESCRIPTION
As mentioned in the documentation of Ubuntu's package repositories, the old key expired on 2023-12-14 and no longer works. They have provided a replacement, and I have replaced the old key's reference with that of the new key.

> The 3A79BD29 key expires on 2023-12-14. A new replacement key (A8D3785C) will sign upcoming MySQL
> 8.0.36 and higher packages
>
> -- https://dev.mysql.com/doc/refman/8.0/en/checking-gpg-signature.html

In addition to this change, I have added some lines to the `docker-compose.yml` file to publish the ports on which MySQL is running in the simple configuration, and to keep all the three containers in the same named Docker network. This was useful when I wanted to connect from another Docker container to one of the DBs. (I was running sysbench from a Docker container without installing it locally.)